### PR TITLE
New features added to C++/libmatrix

### DIFF
--- a/C++/libmatrix/CHANGELOG.md
+++ b/C++/libmatrix/CHANGELOG.md
@@ -1,0 +1,8 @@
+### Changelogs
+As of Oct 11, 2022
+- Overloaded `operator[]` for `matrix`.
+- Added constructor for 2D `std::initializer_list`
+- Added reference counter for memory management.
+- Overloaded `=` and added copy constructor.
+- Private default constructor to avoid `nullptr`.
+- Added assert to avoid matrix of compund types.

--- a/C++/libmatrix/CHANGELOG.md
+++ b/C++/libmatrix/CHANGELOG.md
@@ -1,8 +1,29 @@
-### Changelogs
-As of Oct 11, 2022
-- Overloaded `operator[]` for `matrix`.
-- Added constructor for 2D `std::initializer_list`
-- Added reference counter for memory management.
-- Overloaded `=` and added copy constructor.
-- Private default constructor to avoid `nullptr`.
-- Added assert to avoid matrix of compund types.
+### Changelog - Oct 11, 2022
+#### Overloaded operator [ ]
+```c++
+matrix<int> m(5, 5);
+m[2][3] = 11;
+```
+
+#### Constructor for 2D std::initializer_list
+```c++
+matrix<int> m2 {
+    { 0, 2, 3, 4 },
+    { 7, 1, 5, 6 },
+    { 6, 5, 2, 7 },
+    { 4, 3, 2, 3 }
+};
+```
+
+#### Disabled default constructor
+This is done to make sure a matrix always has its attributes (dimensions and data) defined.
+
+This eliminates need to check a matrix for a nullptr attribute.
+```c++
+matrix<int> m;    // error
+```
+
+####  Excess features
+1. Reference counter for smart memory management.
+2. Overload `=` and add copy constructor.
+3. Added 2 compiler flags to [library.md](library.md#compiler-flags)

--- a/C++/libmatrix/README.md
+++ b/C++/libmatrix/README.md
@@ -1,5 +1,6 @@
 # Matrix Library
 A template library for matrix operations.
+Visit [changelog](CHANGELOG.md).
 
 ### Usage
 View [library.md](library.md) for a list of all the member variables and functions available.

--- a/C++/libmatrix/demo.cpp
+++ b/C++/libmatrix/demo.cpp
@@ -16,21 +16,21 @@ int main()
         { 4, 3, 2, 3 }
     };
 
-    std::cout << "\n>> my matrix:\n";
+    cout << "\n>> my matrix:\n";
     for (int i = 0; i < m2.rows(); i++) {
         for (int j = 0; j < m2.cols(); j++)
-            std::cout << m2[i][j] << " ";
-        std::cout << "\n";
+            cout << m2[i][j] << " ";
+        cout << "\n";
     }
 
     // 4x4 unit matrix
     matrix<int> im = Matrix::I<int>(4);
 
-    std::cout << "\n>> my unit matrix:\n";
+    cout << "\n>> my unit matrix:\n";
     for (int i = 0; i < im.rows(); i++) {
         for (int j = 0; j < im.cols(); j++)
-            std::cout << im[i][j] << " ";
-        std::cout << "\n";
+            cout << im[i][j] << " ";
+        cout << "\n";
     }
 
     cout << "\nequality = ";
@@ -38,7 +38,7 @@ int main()
     else cout << "unequal\n";
 
     try {
-        std::cout << "\n>> sum:\n";
+        cout << "\n>> sum:\n";
         matrix<int> sum = m2 + im;
         sum.print();
     } catch (Matrix::Exception ex) {
@@ -47,7 +47,7 @@ int main()
     }
     try {
         matrix<int> diff = m2 - im;
-        std::cout << "\n>> difference:\n";
+        cout << "\n>> difference:\n";
         diff.print();
     } catch (Matrix::Exception ex) {
         if (ex == Matrix::EX_INCMP)

--- a/C++/libmatrix/demo.cpp
+++ b/C++/libmatrix/demo.cpp
@@ -8,7 +8,7 @@ int main()
     using namespace std;        // standard namespace
     using namespace Matrix;     // namespace for this library
 
-    // the constructor accepts address to 1st element of the C++ DDA
+    // matrix accepts std::initializer_list
     matrix<int> m2 = {
         { 0, 2, 3, 4 },
         { 7, 1, 5, 6 },

--- a/C++/libmatrix/demo.cpp
+++ b/C++/libmatrix/demo.cpp
@@ -6,46 +6,59 @@
 int main()
 {
     using namespace std;        // standard namespace
-    using namespace mtx;        // namespace for this library
+    using namespace Matrix;     // namespace for this library
 
-    // 4x4 unit matrix
-    Matrix<double> im = Matrix<double>::I(4);
-
-    // 4x4 matrix as C++ DDA
-    double m2arr[4][4] = {
+    // the constructor accepts address to 1st element of the C++ DDA
+    matrix<int> m2 = {
         { 0, 2, 3, 4 },
         { 7, 1, 5, 6 },
         { 6, 5, 2, 7 },
         { 4, 3, 2, 3 }
     };
 
-    // the constructor accepts address to 1st element of the C++ DDA
-    Matrix<double> m2 = Matrix<double>(4, 4, &m2arr[0][0]);
+    std::cout << "\n>> my matrix:\n";
+    for (int i = 0; i < m2.rows(); i++) {
+        for (int j = 0; j < m2.cols(); j++)
+            std::cout << m2[i][j] << " ";
+        std::cout << "\n";
+    }
 
-    cout << "\nResult = ";
+    // 4x4 unit matrix
+    matrix<int> im = Matrix::I<int>(4);
+
+    std::cout << "\n>> my unit matrix:\n";
+    for (int i = 0; i < im.rows(); i++) {
+        for (int j = 0; j < im.cols(); j++)
+            std::cout << im[i][j] << " ";
+        std::cout << "\n";
+    }
+
+    cout << "\nequality = ";
     if (m2 == im) cout << "equal\n";
     else cout << "unequal\n";
 
     try {
-        Matrix<double> im = Matrix<double>::I(2);
-        Matrix<double> sum = m2 + im;
-    } catch (mtx::Exception error) {
-        if (error == E_INCMP)
+        std::cout << "\n>> sum:\n";
+        matrix<int> sum = m2 + im;
+        sum.print();
+    } catch (Matrix::Exception ex) {
+        if (ex == Matrix::EX_INCMP)
             cout << "incompatible matrices!\n";
     }
     try {
-        Matrix<double> sum = m2 + im;
-        sum.print();
-    } catch (mtx::Exception error) {
-        if (error == E_INCMP)
+        matrix<int> diff = m2 - im;
+        std::cout << "\n>> difference:\n";
+        diff.print();
+    } catch (Matrix::Exception ex) {
+        if (ex == Matrix::EX_INCMP)
             cout << "incompatible matrices!\n";
     }
 
-    cout << "\ninverse of matrix:\n";
+    cout << "\n>> inverse of my matrix:\n";
     try {
         m2.inverse().print();
-    } catch (mtx::Exception error) {
-        if (error == E_DETR0)
+    } catch (Matrix::Exception ex) {
+        if (ex == Matrix::EX_DETR0)
             cout << "can't invert, determinant = 0!\n";
     }
     return 0;

--- a/C++/libmatrix/libmatrix.hpp
+++ b/C++/libmatrix/libmatrix.hpp
@@ -23,7 +23,8 @@ namespace Matrix
     static const int EX_NULLPTR = 100;    // null pointer exception
 
     /**
-     * Throw an exception with value = Exception code.
+     * Throw an exception with value = exception code.
+     * @throws Matrix::Exception
      */
     void throwException(Exception ex, const std::string& msg)
     {
@@ -66,8 +67,8 @@ namespace Matrix
          * Create a new matrix object.
          * @param rows If DDA is unknown, pass no. of rows
          * @param cols If DDA is unknown, pass no. of cols
-         * @throws Matrix::Exception matrix can't have 0 rows - EX_0ROWS
-         * @throws Matrix::Exception matrix can't have 0 columns - EX_0COLS
+         * @throws Matrix::Exception Matrix can't have 0 rows - EX_0ROWS
+         * @throws Matrix::Exception Matrix can't have 0 columns - EX_0COLS
          */
         matrix(int rows, int cols)
         {
@@ -88,9 +89,9 @@ namespace Matrix
 
         /**
          * Create a new matrix object.
-         * @param initialiser list
-         * @throws Matrix::Exception matrix can't have 0 rows - EX_0ROWS
-         * @throws Matrix::Exception matrix can't have 0 columns - EX_0COLS
+         * @param lst 2D Initialiser list
+         * @throws Matrix::Exception Matrix can't have 0 rows - EX_0ROWS
+         * @throws Matrix::Exception Matrix can't have 0 columns - EX_0COLS
          */
         matrix(std::initializer_list<std::initializer_list<type>> lst)
         {
@@ -121,8 +122,8 @@ namespace Matrix
          * @param rows Row size of DDA
          * @param cols Column size of DDA
          * @param arr If DDA is known, pass &dda[0][0]
-         * @throws Matrix::Exception matrix can't have 0 rows - EX_0ROWS
-         * @throws Matrix::Exception matrix can't have 0 columns - EX_0COLS
+         * @throws Matrix::Exception Matrix can't have 0 rows - EX_0ROWS
+         * @throws Matrix::Exception Matrix can't have 0 columns - EX_0COLS
          */
         matrix(int rows, int cols, type *arr)
         {
@@ -219,11 +220,11 @@ namespace Matrix
 
         /**
          * Get an element of the matrix from an index.
-         * @param i row wise position of element
-         * @param j column wise position of element
+         * @param i Row wise position of element
+         * @param j Column wise position of element
          * @return <type> The value at index i, j
-         * @throws Matrix::Exception row index out of bounds - EX_ROUTB
-         * @throws Matrix::Exception column index out of bounds - EX_COUTB
+         * @throws Matrix::Exception Row index out of bounds - EX_ROUTB
+         * @throws Matrix::Exception Column index out of bounds - EX_COUTB
          */
         type get(int i, int j)
         {
@@ -236,11 +237,11 @@ namespace Matrix
 
         /**
          * Set an element of the matrix to an index.
-         * @param i row wise position of element
-         * @param j column wise position of element
-         * @param val value to be set
-         * @throws Matrix::Exception row index out of bounds - EX_ROUTB
-         * @throws Matrix::Exception column index out of bounds - EX_COUTB
+         * @param i Row wise position of element
+         * @param j Column wise position of element
+         * @param val Value to be set
+         * @throws Matrix::Exception Row index out of bounds - EX_ROUTB
+         * @throws Matrix::Exception Column index out of bounds - EX_COUTB
          */
         void set(int i, int j, type val)
         {
@@ -253,7 +254,7 @@ namespace Matrix
 
         /**
          * Access a posn of the matrix.
-         * @param int row
+         * @param i Row of matrix
          */
         type*& operator[](int i) const
         {
@@ -263,7 +264,7 @@ namespace Matrix
         /*
          * Compares two matrices for equality.
          * @param m2 The matrix to compare to
-         * @return boolean true if equal
+         * @return boolean True if equal
          */
         bool equals(const matrix<type>& m2)
         {
@@ -353,7 +354,7 @@ namespace Matrix
          * Calculate matrix to the power of +ve integer.
          * @param index Power of matrix
          * @return matrix<type> The resulting matrix
-         * @throws Matrix::Exception same as Exceptions of matrix::multiply method
+         * @throws Matrix::Exception Same as Exceptions of matrix::multiply method
          */
         matrix<type> power(int index)
         {
@@ -368,7 +369,7 @@ namespace Matrix
         /*
          * Compares two matrices for equality.
          * @param m2 The matrix to compare to
-         * @return boolean true if equal
+         * @return boolean True if equal
          */
         bool operator==(const matrix<type>& m2)
         {
@@ -422,7 +423,7 @@ namespace Matrix
          * Calculate matrix to the power of +ve integer
          * @param index Power of matrix
          * @return matrix<type> The resulting matrix
-         * @throws Matrix::Exception same as Exceptions of matrix::multiply method
+         * @throws Matrix::Exception Same as Exceptions of matrix::multiply method
          */
         matrix<type> operator^(int index)
         {
@@ -435,8 +436,8 @@ namespace Matrix
          * @param row The row to exclude
          * @param col The column to exclude
          * @return matrix<type> The sub matrix
-         * @throws Matrix::Exception row index out of bounds - EX_ROUTB
-         * @throws Matrix::Exception column index out of bounds - EX_COUTB
+         * @throws Matrix::Exception Row index out of bounds - EX_ROUTB
+         * @throws Matrix::Exception Column index out of bounds - EX_COUTB
          */
         matrix<type> excludeRowCol(int row, int col)
         {
@@ -597,11 +598,11 @@ namespace Matrix
 
     /**
      * Create a null matrix of given size.
-     * @param n rows of matrix
-     * @param cols? cols of matrix
-     * @return matrix<type> a null matrix
-     * @throws Matrix::Exception row index out of bounds - EX_ROUTB
-     * @throws Matrix::Exception column index out of bounds - EX_COUTB
+     * @param n Rows of matrix
+     * @param cols? Cols of matrix
+     * @return matrix<type> A null matrix
+     * @throws Matrix::Exception Row index out of bounds - EX_ROUTB
+     * @throws Matrix::Exception Column index out of bounds - EX_COUTB
      */
     template <typename type>
     matrix<type> O(int n, int cols = 0)
@@ -613,10 +614,10 @@ namespace Matrix
 
     /**
      * Create a unit matrix of given size.
-     * @param n size of matrix
-     * @return matrix<type> a unit matrix
-     * @throws Matrix::Exception row index out of bounds - EX_ROUTB
-     * @throws Matrix::Exception column index out of bounds - EX_COUTB
+     * @param n Size of matrix
+     * @return matrix<type> A unit matrix
+     * @throws Matrix::Exception Row index out of bounds - EX_ROUTB
+     * @throws Matrix::Exception Column index out of bounds - EX_COUTB
      */
     template <typename type>
     matrix<type> I(int n)

--- a/C++/libmatrix/libmatrix.hpp
+++ b/C++/libmatrix/libmatrix.hpp
@@ -37,8 +37,9 @@ namespace Matrix
     template <typename type>
     class matrix
     {
+    #ifdef ALLOW_PRIMITIVES_ONLY
         static_assert(std::is_fundamental<type>::value, "Matrix::matrix: template argument should be a primitive type");
-
+    #endif
     public:
         /**
          * Only another matrix can access properties of a matrix directly

--- a/C++/libmatrix/libmatrix.hpp
+++ b/C++/libmatrix/libmatrix.hpp
@@ -500,5 +500,65 @@ namespace mtx
                 std::cout << "\n";
             }
         }
+
+    private:
+        /**
+         * Row number of this matrix.
+         */
+        int *rows_ptr;
+
+        /**
+         * Column number of this matrix.
+         */
+        int *cols_ptr;
+
+        /**
+         * Double pointer to matrix data location.
+         */
+        type **mtx_ptr;
+
+        /**
+         * Stores a count of references.
+         */
+        int *refcnt_ptr;
+
+        /**
+         * Default constructor.
+         */
+        matrix()
+            : rows_ptr(nullptr), cols_ptr(nullptr), mtx_ptr(nullptr), refcnt_ptr(nullptr)
+        {}
     };
+
+    /**
+     * Create a null matrix of given size.
+     * @param n rows of matrix
+     * @param cols? cols of matrix
+     * @return matrix<type> a null matrix
+     * @throws Matrix::Exception row index out of bounds - EX_ROUTB
+     * @throws Matrix::Exception column index out of bounds - EX_COUTB
+     */
+    template <typename type>
+    matrix<type> O(int n, int cols = 0)
+    {
+        if (cols == 0)
+            cols = n;
+        return matrix<type>(n, cols);
+    }
+
+    /**
+     * Create a unit matrix of given size.
+     * @param n size of matrix
+     * @return matrix<type> a unit matrix
+     * @throws Matrix::Exception row index out of bounds - EX_ROUTB
+     * @throws Matrix::Exception column index out of bounds - EX_COUTB
+     */
+    template <typename type>
+    matrix<type> I(int n)
+    {
+        matrix<type> im = matrix<type>(n, n);
+        for (int i = 0; i < n; i++)
+            im[i][i] = 1;
+        return im;
+    }
 }

--- a/C++/libmatrix/libmatrix.hpp
+++ b/C++/libmatrix/libmatrix.hpp
@@ -492,76 +492,76 @@ namespace Matrix
         }
 
         /**
-         * Calculate the transpose of this matrix
-         * @return Matrix<type> The transpose
+         * Calculate the transpose of this matrix.
+         * @return matrix<type> The transpose
          */
-        Matrix<type> transpose()
+        matrix<type> transpose()
         {
-            Matrix<type> nm = Matrix<type>(this->cols, this->rows);
-            for (int i = 0; i < this->rows; i++)
-                for (int j = 0; j < this->cols; j++)
-                    nm.set(j, i, this->get(i, j));
+            matrix<type> nm = matrix<type>(this->cols(), this->rows());
+            for (int i = 0; i < this->rows(); i++)
+                for (int j = 0; j < this->cols(); j++)
+                    nm[j][i] = this->mtx_ptr[i][j];
             return nm;
         }
 
         /**
-         * Calculate the cofactor matrix of this matrix
-         * @return Matrix<type> The cofactor matrix
-         * @throws Exception If matrix isn't a square matrix - E_NOSQR
+         * Calculate the cofactor matrix of this matrix.
+         * @return matrix<type> The cofactor matrix
+         * @throws Matrix::Exception If matrix isn't a square matrix - EX_NOSQR
          */
-        Matrix<type> cofactor()
+        matrix<type> cofactor()
         {
-            if (this->rows != this->cols)
-                this->throwException(E_NOSQR, "not a square matrix");
-            Matrix<type> nm = Matrix<type>(this->rows, this->cols);
-            for (int i = 0; i < this->rows; i++)
-                for (int j = 0; j < this->cols; j++) {
+            if (this->rows() != this->cols())
+                Matrix::throwException(EX_NOSQR, "not a square matrix");
+            matrix<type> nm = matrix<type>(this->rows(), this->cols());
+            for (int i = 0; i < this->rows(); i++)
+                for (int j = 0; j < this->cols(); j++) {
                     double coeff = pow(-1, i + 1 + j + 1);
-                    Matrix<type> subm = this->excludeRowCol(i, j);
-                    nm.set(i, j, coeff * subm.determinant());
+                    matrix<type> subm = this->excludeRowCol(i, j);
+                    nm[i][j] = coeff * subm.determinant();
                 }
             return nm;
         }
 
         /**
-         * Calculate the adjoint of this matrix
-         * @return Matrix<type> The adjoint
-         * @throws Exception If matrix isn't a square matrix - E_NOSQR
+         * Calculate the adjoint of this matrix.
+         * @return matrix<type> The adjoint
+         * @throws Matrix::Exception If matrix isn't a square matrix - EX_NOSQR
          */
-        Matrix<type> adjoint()
+        matrix<type> adjoint()
         {
-            if (this->rows != this->cols)
-                this->throwException(E_NOSQR, "not a square matrix");
+            if (this->rows() != this->cols())
+                Matrix::throwException(EX_NOSQR, "not a square matrix");
             return this->cofactor().transpose();
         }
 
         /**
-         * Calculate the inverse of this matrix
-         * @return Matrix<double> The inverse
-         * @throws Exception If matrix isn't a square matrix - E_NOSQR
-         * @throws Exception If determinant is 0 - E_DETR0
+         * Calculate the inverse of this matrix.
+         * @return matrix<double> The inverse
+         * @throws Matrix::Exception If matrix isn't a square matrix - EX_NOSQR
+         * @throws Matrix::Exception If determinant is 0 - EX_DETR0
          */
-        Matrix<double> inverse()
+        matrix<double> inverse()
         {
-            if (this->rows != this->cols)
-                this->throwException(E_NOSQR, "not a square matrix");
+            if (this->rows() != this->cols())
+                Matrix::throwException(EX_NOSQR, "not a square matrix");
             double determinant = this->determinant();
             if (determinant == 0)
-                this->throwException(E_DETR0, "determinant is 0");
-            return this->adjoint().scale(1/determinant).toDoubleMatrix();
+                Matrix::throwException(EX_DETR0, "determinant is 0");
+            return this->toDoubleMatrix().adjoint().scale(1/determinant);
         }
 
         /**
-         * Display the matrix
+         * Display the matrix.
          * @param msg? The message to print
          */
         void print(const std::string& msg = "")
         {
             if (msg != "")
                 std::cout << msg << "\n";
-            for (int i = 0; i < this->rows; i++) {
-                for (int j = 0; j < this->cols; j++)
-                    std::cout << this->get(i, j) << ((j < this->cols -1)? ", " : "");
+            for (int i = 0; i < this->rows(); i++) {
+                for (int j = 0; j < this->cols(); j++)
+                    std::cout << this->mtx_ptr[i][j] << ((j < this->cols() -1)? ", " : "");
                 std::cout << "\n";
             }
         }

--- a/C++/libmatrix/libmatrix.hpp
+++ b/C++/libmatrix/libmatrix.hpp
@@ -5,22 +5,22 @@
 
 namespace Matrix
 {
-    // type error
-    typedef const std::string& Exception;
+    template <typename type> class matrix;
+
+    // type Exception
+    typedef const int Exception;
 
     // possible exceptions
-    const char *E_0ROWS = "E_0ROWS";
-    const char *E_0COLS = "E_0COLS";
-    const char *E_ROUTB = "E_ROUTB";
-    const char *E_COUTB = "E_COUTB";
-    const char *E_INCMP = "E_INCMP";
-    const char *E_NOSQR = "E_NOSQR";
-    const char *E_DETR0 = "E_DETR0";
+    static const int EX_0ROWS = 10;       // matrix can't have 0 rows
+    static const int EX_0COLS = 20;       // matrix can't have 0 columns
+    static const int EX_ROUTB = 30;       // row index out of bounds
+    static const int EX_COUTB = 40;       // column index out of bounds
+    static const int EX_INCMP = 50;       // incompatible matrices
+    static const int EX_NOSQR = 60;       // not a square matrix
+    static const int EX_DETR0 = 70;       // during inversion, determinant is 0
 
-    template <typename type>
-    class Matrix
-    {
-    public:
+    // more general exceptions
+    static const int EX_NULLPTR = 100;    // null pointer exception
 
     /**
      * Throw an exception with value = Exception code.

--- a/C++/libmatrix/libmatrix.hpp
+++ b/C++/libmatrix/libmatrix.hpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <string>
 
-namespace mtx
+namespace Matrix
 {
     // type error
     typedef const std::string& Exception;
@@ -22,10 +22,16 @@ namespace mtx
     {
     public:
 
-        /**
-         * Row number of this matrix
-         */
-        int rows;
+    /**
+     * Throw an exception with value = Exception code.
+     */
+    void throwException(Exception ex, const std::string& msg)
+    {
+    #ifdef DEBUG
+        std::cout << "Matrix::Exception::" << ex << ": " << msg << "\n";
+    #endif
+        throw ex;
+    }
 
         /**
          * Column number of this matrix

--- a/C++/libmatrix/libmatrix.hpp
+++ b/C++/libmatrix/libmatrix.hpp
@@ -33,398 +33,457 @@ namespace Matrix
         throw ex;
     }
 
+    template <typename type>
+    class matrix
+    {
+        static_assert(std::is_fundamental<type>::value, "Matrix::matrix: template argument should be a primitive type");
+
+    public:
         /**
-         * Column number of this matrix
+         * Only another matrix can access properties of a matrix directly
          */
-        int cols;
+        template <typename T> friend class matrix;
 
         /**
-         * Double pointer to matrix data location
+         * Get row count of matrix.
+         * @return int
          */
-        type **matrix;
-
-        /**
-         * Create a null matrix of given size
-         * @param n rows of matrix
-         * @param cols? cols of matrix
-         * @return Matrix<type> a null matrix
-         * @throws Exception row index out of bounds - E_ROUTB
-         * @throws Exception column index out of bounds - E_COUTB
-         */
-        static Matrix<type> O(int n, int cols = 0)
+        int rows() const
         {
-            if (cols == 0)
-                cols = n;
-            return Matrix<type>(n, cols, true);
+            return (int) *this->rows_ptr;
         }
 
         /**
-         * Create a unit matrix of given size
-         * @param n size of matrix
-         * @return Matrix<type> a unit matrix
-         * @throws Exception row index out of bounds - E_ROUTB
-         * @throws Exception column index out of bounds - E_COUTB
+         * Get column count of matrix.
+         * @return int
          */
-        static Matrix<type> I(int n)
+        int cols() const
         {
-            Matrix<type> im = Matrix<type>(n, n);
-            for (int i = 0; i < n; i++)
-                im.set(i, i, 1);
-            return im;
+            return (int) *this->cols_ptr;
         }
 
         /**
-         * Default constructor
-         */
-        explicit Matrix()
-        {
-            this->rows = 0;
-            this->cols = 0;
-            this->matrix = nullptr;
-        }
-
-        /**
-         * Create a new Matrix object
+         * Create a new matrix object.
          * @param rows If DDA is unknown, pass no. of rows
          * @param cols If DDA is unknown, pass no. of cols
-         * @throws Exception matrix can't have 0 rows - E_0ROWS
-         * @throws Exception matrix can't have 0 columns - E_0COLS
+         * @throws Matrix::Exception matrix can't have 0 rows - EX_0ROWS
+         * @throws Matrix::Exception matrix can't have 0 columns - EX_0COLS
          */
-        explicit Matrix(int rows, int cols)
+        matrix(int rows, int cols)
         {
             if (rows < 1)
-                this->throwException(E_0ROWS, "matrix can't have 0 rows");
+                Matrix::throwException(EX_0ROWS, "matrix can't have 0 rows");
             if (cols < 1)
-                this->throwException(E_0COLS, "matrix can't have 0 columns");
-            this->rows = rows;
-            this->cols = cols;
-            this->matrix = new type*[rows];
-            for (int i = 0; i < this->rows; i++) {
-                this->matrix[i] = new type[cols];
-                for (int j = 0; j < this->cols; j++)
-                    this->set(i, j, 0);
+                Matrix::throwException(EX_0COLS, "matrix can't have 0 columns");
+            this->rows_ptr = new int(rows);
+            this->cols_ptr = new int(cols);
+            this->mtx_ptr = new type*[rows];
+            for (int i = 0; i < this->rows(); i++) {
+                this->mtx_ptr[i] = new type[cols];
+                for (int j = 0; j < this->cols(); j++)
+                    this->mtx_ptr[i][j] = 0;
             }
+            this->refcnt_ptr = new int(1);
         }
 
         /**
-         * Create a new Matrix object
+         * Create a new matrix object.
+         * @param initialiser list
+         * @throws Matrix::Exception matrix can't have 0 rows - EX_0ROWS
+         * @throws Matrix::Exception matrix can't have 0 columns - EX_0COLS
+         */
+        matrix(std::initializer_list<std::initializer_list<type>> lst)
+        {
+            int rows = lst.size();
+            int cols = lst.begin()->size();
+            if (rows < 1)
+                Matrix::throwException(EX_0ROWS, "matrix can't have 0 rows");
+            if (cols < 1)
+                Matrix::throwException(EX_0COLS, "matrix can't have 0 columns");
+            this->rows_ptr = new int(rows);
+            this->cols_ptr = new int(cols);
+            this->mtx_ptr = new type*[rows];
+            int i = 0;
+            for (const auto& lrow : lst) {
+                this->mtx_ptr[i] = new type[cols];
+                int j = 0;
+                for (const auto& el : lrow) {
+                    this->mtx_ptr[i][j] = el;
+                    j++;
+                }
+                i++;
+            }
+            this->refcnt_ptr = new int(1);
+        }
+
+        /**
+         * Create a new matrix object.
          * @param rows Row size of DDA
          * @param cols Column size of DDA
          * @param arr If DDA is known, pass &dda[0][0]
-         * @throws Exception matrix can't have 0 rows - E_0ROWS
-         * @throws Exception matrix can't have 0 columns - E_0COLS
+         * @throws Matrix::Exception matrix can't have 0 rows - EX_0ROWS
+         * @throws Matrix::Exception matrix can't have 0 columns - EX_0COLS
          */
-        explicit Matrix(int rows, int cols, type *arr)
+        matrix(int rows, int cols, type *arr)
         {
             if (rows < 1)
-                this->throwException(E_0ROWS, "matrix can't have 0 rows");
+                Matrix::throwException(EX_0ROWS, "matrix can't have 0 rows");
             if (cols < 1)
-                this->throwException(E_0COLS, "matrix can't have 0 columns");
-            this->rows = rows;
-            this->cols = cols;
-            this->matrix = new type*[rows];
-            for (int i = 0; i < this->rows; i++) {
-                this->matrix[i] = new type[cols];
-                for (int j = 0; j < this->cols; j++)
-                    this->set(i, j, arr[i*cols +j]);
+                Matrix::throwException(EX_0COLS, "matrix can't have 0 columns");
+            this->rows_ptr = new int(rows);
+            this->cols_ptr = new int(cols);
+            this->mtx_ptr = new type*[rows];
+            for (int i = 0; i < this->rows(); i++) {
+                this->mtx_ptr[i] = new type[cols];
+                for (int j = 0; j < this->cols(); j++)
+                    this->mtx_ptr[i][j] = arr[i*cols +j];
             }
+            this->refcnt_ptr = new int(1);
         }
 
         /**
-         * Constructs a Matrix<double> from a Matrix<type>
+         * Copy a matrix object via constructor.
+         * matrix uses smart reference counting approach. When all references are cleared, the memory is auto deleted.
+         * @param m2 The source matrix
          */
-        Matrix<double> toDoubleMatrix()
+        matrix(const matrix<type>& m2)
         {
-            Matrix<double> dm;
-            dm.rows = this->rows;
-            dm.cols = this->cols;
-            dm.matrix = new double*[rows];
-            for (int i = 0; i < dm.rows; i++) {
-                dm.matrix[i] = new double[cols];
-                for (int j = 0; j < dm.cols; j++)
-                    dm.set(i, j, (double) this->get(i, j));
+            if (!m2.refcnt_ptr) Matrix::throwException(EX_NULLPTR, "null pointer exception");
+            this->mtx_ptr = m2.mtx_ptr;
+            this->rows_ptr = m2.rows_ptr;
+            this->cols_ptr = m2.cols_ptr;
+            this->refcnt_ptr = m2.refcnt_ptr;
+            (*this->refcnt_ptr)++;
+        }
+
+        /**
+         * Copy a matrix object through assignment.
+         * matrix uses smart reference counting approach. When all references are cleared, the memory is auto deleted.
+         * @param m2 The source matrix
+         */
+        matrix<type> operator=(const matrix<type>& m2)
+        {
+            if (!m2.refcnt_ptr) Matrix::throwException(EX_NULLPTR, "null pointer exception");
+            // release old matrix data
+            (*this->refcnt_ptr)--;
+            if ((*this->refcnt_ptr) == 0) {
+                for (int i = 0; i < this->rows(); i++)
+                    delete[] this->mtx_ptr[i];
+                delete[] this->mtx_ptr;
+                delete this->rows_ptr;
+                delete this->cols_ptr;
+                delete this->refcnt_ptr;
+            }
+            // catch new matrix data
+            this->mtx_ptr = m2.mtx_ptr;
+            this->rows_ptr = m2.rows_ptr;
+            this->cols_ptr = m2.cols_ptr;
+            this->refcnt_ptr = m2.refcnt_ptr;
+            (*this->refcnt_ptr)++;
+            return *this;
+        }
+
+        /**
+         * Construct a matrix<double> from a matrix<type>.
+         */
+        matrix<double> toDoubleMatrix()
+        {
+            matrix<double> dm;
+            dm.rows_ptr = new int(this->rows());
+            dm.cols_ptr = new int(this->cols());
+            dm.refcnt_ptr = new int(1);
+            dm.mtx_ptr = new double*[this->rows()];
+            for (int i = 0; i < dm.rows(); i++) {
+                dm.mtx_ptr[i] = new double[this->cols()];
+                for (int j = 0; j < dm.cols(); j++)
+                    dm[i][j] = (double) this->mtx_ptr[i][j];
             }
             return dm;
         }
 
         /**
-         * Clears the array of the matrix instance on scope exit
+         * Clears the array of the matrix instance on scope exit.
          */
-        ~Matrix()
+        ~matrix()
         {
-            for (int i = 0; i < this->rows; i++)
-                delete[] this->matrix[i];
-            delete[] this->matrix;
+            (*this->refcnt_ptr)--;
+            if ((*this->refcnt_ptr) == 0) {
+                for (int i = 0; i < this->rows(); i++)
+                    delete[] this->mtx_ptr[i];
+                delete[] this->mtx_ptr;
+                delete this->rows_ptr;
+                delete this->cols_ptr;
+                delete this->refcnt_ptr;
+            }
         }
 
         /**
-         * Throw an exception with value = error code
-         */
-        void throwException(const std::string& errcode, const std::string& msg)
-        {
-        #ifdef DEBUG
-            std::cout << "error: " << errcode << ": " << msg << "\n";
-        #endif
-            throw errcode;
-        }
-
-        /**
-         * Get an element of the matrix from an index
+         * Get an element of the matrix from an index.
          * @param i row wise position of element
          * @param j column wise position of element
          * @return <type> The value at index i, j
-         * @throws Exception row index out of bounds - E_ROUTB
-         * @throws Exception column index out of bounds - E_COUTB
+         * @throws Matrix::Exception row index out of bounds - EX_ROUTB
+         * @throws Matrix::Exception column index out of bounds - EX_COUTB
          */
         type get(int i, int j)
         {
-            if (i < 0 || i > this->rows)
-                this->throwException(E_ROUTB, "row index out of bounds");
-            if (j < 0 || j > this->rows)
-                this->throwException(E_COUTB, "column index out of bounds");
-            return this->matrix[i][j];
+            if (i < 0 || i > this->rows())
+                Matrix::throwException(EX_ROUTB, "row index out of bounds");
+            if (j < 0 || j > this->rows())
+                Matrix::throwException(EX_COUTB, "column index out of bounds");
+            return this->mtx_ptr[i][j];
         }
 
         /**
-         * Set an element of the matrix to an index
+         * Set an element of the matrix to an index.
          * @param i row wise position of element
          * @param j column wise position of element
          * @param val value to be set
-         * @throws Exception row index out of bounds - E_ROUTB
-         * @throws Exception column index out of bounds - E_COUTB
+         * @throws Matrix::Exception row index out of bounds - EX_ROUTB
+         * @throws Matrix::Exception column index out of bounds - EX_COUTB
          */
         void set(int i, int j, type val)
         {
-            if (i < 0 || i > this->rows)
-                this->throwException(E_ROUTB, "row index out of bounds");
-            if (j < 0 || j > this->cols)
-                this->throwException(E_COUTB, "column index out of bounds");
-            this->matrix[i][j] = val;
+            if (i < 0 || i > this->rows())
+                Matrix::throwException(EX_ROUTB, "row index out of bounds");
+            if (j < 0 || j > this->cols())
+                Matrix::throwException(EX_COUTB, "column index out of bounds");
+            this->mtx_ptr[i][j] = val;
+        }
+
+        /**
+         * Access a posn of the matrix.
+         * @param int row
+         */
+        type*& operator[](int i) const
+        {
+            return this->mtx_ptr[i];
         }
 
         /*
-         * Compares two matrices for equality
+         * Compares two matrices for equality.
          * @param m2 The matrix to compare to
          * @return boolean true if equal
          */
-        bool equals(Matrix<type>& m2)
+        bool equals(const matrix<type>& m2)
         {
-            if (this->rows != m2.rows || this->cols != m2.cols)
+            if (this->rows() != m2.rows() || this->cols() != m2.cols())
                 return false;
-            for (int i = 0; i < this->rows; i++)
-                for (int j = 0; j < this->cols; j++)
-                    if (this->get(i, j) != m2.get(i, j))
+            for (int i = 0; i < this->rows(); i++)
+                for (int j = 0; j < this->cols(); j++)
+                    if (this->mtx_ptr[i][j] != m2[i][j])
                         return false;
             return true;
         }
 
         /**
-         * Add two compatible matrices
+         * Add two compatible matrices.
          * @param m2 The matrix to add
-         * @return Matrix<type> The matrix of sums
-         * @throws Exception If matrices aren't compatible - E_INCMP
+         * @return matrix<type> The matrix of sums
+         * @throws Matrix::Exception If matrices aren't compatible - EX_INCMP
          */
-        Matrix<type> add(Matrix<type>& m2, bool sub = false)
+        matrix<type> add(const matrix<type>& m2, bool sub = false)
         {
-            if (m2.rows != this->rows || m2.cols != this->cols)
-                this->throwException(E_INCMP, "incompatible matrices for addition");
-            Matrix<type> nm = Matrix<type>(this->rows, this->cols);
-            for (int i = 0; i < this->rows; i++)
-                for (int j = 0; j < this->cols; j++) {
-                    type rslt = this->get(i, j) + (sub ? (-1) * m2.get(i, j) : m2.get(i, j));
-                    nm.set(i, j, rslt);
+            if (m2.rows() != this->rows() || m2.cols() != this->cols())
+                Matrix::throwException(EX_INCMP, "incompatible matrices for addition");
+            matrix<type> nm = matrix<type>(this->rows(), this->cols());
+            for (int i = 0; i < this->rows(); i++)
+                for (int j = 0; j < this->cols(); j++) {
+                    type rslt = this->mtx_ptr[i][j] + (sub ? (-1) * m2[i][j] : m2[i][j]);
+                    nm[i][j] = rslt;
                 }
             return nm;
         }
 
         /**
-         * Subtract two compatible matrices
+         * Subtract 2nd from 1st matrix.
          * @param m2 The matrix to subtract
-         * @return Matrix<type> The matrix of differences
-         * @throws Exception If matrices aren't compatible - E_INCMP
+         * @return matrix<type> The matrix of differences
+         * @throws Matrix::Exception If matrices aren't compatible - EX_INCMP
          */
-        Matrix<type> subtract(Matrix<type>& m2)
+        matrix<type> subtract(const matrix<type>& m2)
         {
-            if (m2.rows != this->rows || m2.cols != this->cols)
-                this->throwException(E_INCMP, "incompatible matrices for subtraction");
+            if (m2.rows() != this->rows() || m2.cols() != this->cols())
+                Matrix::throwException(EX_INCMP, "incompatible matrices for subtraction");
             return this->add(m2, true);
         }
 
         /**
-         * Multiplies a matrix by a scalar
+         * Multiply a matrix by a scalar.
          * @param scalar Scalar to multiply by
-         * @return Matrix The matrix of products
+         * @return matrix The matrix of products
          */
-        Matrix<type> scale(type scalar)
+        matrix<type> scale(type scalar)
         {
-            Matrix<type> nm = Matrix<type>(this->rows, this->cols);
-            for (int i = 0; i < this->rows; i++)
-                for (int j = 0; j < this->cols; j++) {
-                    type rslt = scalar * this->get(i, j);
-                    nm.set(i, j, rslt);
+            matrix<type> nm = matrix<type>(this->rows(), this->cols());
+            for (int i = 0; i < this->rows(); i++)
+                for (int j = 0; j < this->cols(); j++) {
+                    type rslt = scalar * this->mtx_ptr[i][j];
+                    nm[i][j] = rslt;
                 }
             return nm;
         }
 
         /**
-         * Multiplies two compatible matrices
+         * Multiply two compatible matrices.
          * @param m2 The matrix to multiply by
-         * @return Matrix<type> The matrix after multiplication
-         * @throws Exception If matrices aren't compatible - E_INCMP
+         * @return matrix<type> The matrix after multiplication
+         * @throws Matrix::Exception If matrices aren't compatible - EX_INCMP
          */
-        Matrix<type> multiply(Matrix<type>& m2)
+        matrix<type> multiply(const matrix<type>& m2)
         {
-            if (this->cols != m2.rows)
-                this->throwException(E_INCMP, "incompatible matrices for multiplication");
-            int m = this->rows;
-            int n = this->cols; // same
-            n = m2.rows;        // same
-            int o = m2.cols;
-            Matrix<type> nm = Matrix<type>(m, o);
+            if (this->cols() != m2.rows())
+                Matrix::throwException(EX_INCMP, "incompatible matrices for multiplication");
+            int m = this->rows();
+            int n = this->cols(); // same
+            n = m2.rows();           // same
+            int o = m2.cols();
+            matrix<type> nm = matrix<type>(m, o);
             for (int i = 0; i < m; i++)
                 for (int j = 0; j < o; j++) {
                     double sum = 0;
                     for (int k = 0; k < n; k++)
-                        sum += this->get(i, k) * m2.get(k, j);
-                    nm.set(i, j, sum);
+                        sum += this->mtx_ptr[i][k] * m2[k][j];
+                    nm[i][j] = sum;
                 }
             return nm;
         }
 
         /**
-         * Calculate matrix to the power of index
+         * Calculate matrix to the power of +ve integer.
          * @param index Power of matrix
-         * @return Matrix<type> The resulting matrix
-         * @throws Exception same as errors of Matrix::multiply method
+         * @return matrix<type> The resulting matrix
+         * @throws Matrix::Exception same as Exceptions of matrix::multiply method
          */
-        Matrix<type> power(int index)
+        matrix<type> power(int index)
         {
-            Matrix<type> nm = *this;
+            matrix<type> nm = *this;
             for (int i = 0; i < index - 1; i++) {
-                Matrix<type> tmp = nm.multiply(*this);
+                matrix<type> tmp = nm.multiply(*this);
                 nm = tmp;
             }
             return nm;
         }
 
         /*
-         * Compares two matrices for equality
+         * Compares two matrices for equality.
          * @param m2 The matrix to compare to
          * @return boolean true if equal
          */
-        bool operator==(Matrix<type>& m2)
+        bool operator==(const matrix<type>& m2)
         {
             return this->equals(m2);
         }
 
         /**
-         * Add two compatible matrices
+         * Add two compatible matrices.
          * @param m2 The matrix to add
-         * @return Matrix<type> The matrix of sums
-         * @throws Exception If matrices aren't compatible - E_INCMP
+         * @return matrix<type> The matrix of sums
+         * @throws Matrix::Exception If matrices aren't compatible - EX_INCMP
          */
-        Matrix<type> operator+(Matrix<type>& m2)
+        matrix<type> operator+(const matrix<type>& m2)
         {
             return this->add(m2);
         }
 
         /**
-         * Subtract two compatible matrices
+         * Subtract 2nd from 1st matrix.
          * @param m2 The matrix to subtract
-         * @return Matrix<type> The matrix of differences
-         * @throws Exception If matrices aren't compatible - E_INCMP
+         * @return matrix<type> The matrix of differences
+         * @throws Matrix::Exception If matrices aren't compatible - EX_INCMP
          */
-        Matrix<type> operator-(Matrix<type>& m2)
+        matrix<type> operator-(const matrix<type>& m2)
         {
             return this->subtract(m2);
         }
 
         /**
-         * Multiplies a matrix by a scalar
+         * Multiply a matrix by a scalar.
          * @param scalar Scalar to multiply by
-         * @return Matrix The matrix of products
+         * @return matrix The matrix of products
          */
-        Matrix<type> operator*(type scalar)
+        matrix<type> operator*(type scalar)
         {
             return this->scale(scalar);
         }
 
         /**
-         * Multiplies two compatible matrices
+         * Multiply two compatible matrices.
          * @param m2 The matrix to multiply by
-         * @return Matrix<type> The matrix after multiplication
-         * @throws Exception If matrices aren't compatible - E_INCMP
+         * @return matrix<type> The matrix after multiplication
+         * @throws Matrix::Exception If matrices aren't compatible - EX_INCMP
          */
-        Matrix<type> operator*(Matrix<type>& m2)
+        matrix<type> operator*(const matrix<type>& m2)
         {
             return this->multiply(m2);
         }
 
         /**
-         * Calculate matrix to the power of index
+         * Calculate matrix to the power of +ve integer
          * @param index Power of matrix
-         * @return Matrix<type> The resulting matrix
-         * @throws Exception same as errors of Matrix::multiply method
+         * @return matrix<type> The resulting matrix
+         * @throws Matrix::Exception same as Exceptions of matrix::multiply method
          */
-        Matrix<type> operator^(int index)
+        matrix<type> operator^(int index)
         {
             return this->power(index);
         }
 
         /**
-         * Excludes a row and a column and generates a sub matrix. Useful for calculating determinants and cofactor matrices.
+         * Excludes a row and a column and generates a sub matrix.
+         * Useful for calculating determinants and cofactor matrices.
          * @param row The row to exclude
          * @param col The column to exclude
-         * @return Matrix<type> The sub matrix
-         * @throws Exception row index out of bounds - E_ROUTB
-         * @throws Exception column index out of bounds - E_COUTB
+         * @return matrix<type> The sub matrix
+         * @throws Matrix::Exception row index out of bounds - EX_ROUTB
+         * @throws Matrix::Exception column index out of bounds - EX_COUTB
          */
-        Matrix<type> excludeRowCol(int row, int col)
+        matrix<type> excludeRowCol(int row, int col)
         {
-            if (row < 0 || row > this->rows)
-                this->throwException(E_ROUTB, "row index out of bounds");
-            if (col < 0 || col > this->rows)
-                this->throwException(E_COUTB, "column index out of bounds");
-            Matrix<type> subm = Matrix(this->rows - 1, this->cols - 1);
+            if (row < 0 || row > this->rows())
+                Matrix::throwException(EX_ROUTB, "row index out of bounds");
+            if (col < 0 || col > this->rows())
+                Matrix::throwException(EX_COUTB, "column index out of bounds");
+            matrix<type> subm = matrix<type>(this->rows() - 1, this->cols() - 1);
             bool skipRow = false;
-            for (int j = 0; j < this->rows - 1; j++) {
+            for (int j = 0; j < this->rows() - 1; j++) {
                 bool skipCol = false;
                 int jSelf = j;
                 if (j == row)
                     skipRow = true;
                 if (skipRow)
                     jSelf++;
-                for (int k = 0; k < this->cols - 1; k++) {
+                for (int k = 0; k < this->cols() - 1; k++) {
                     int kSelf = k;
                     if (k == col)
                         skipCol = true;
                     if (skipCol)
                         kSelf++;
-                    subm.set(j, k, this->get(jSelf, kSelf));
+                    subm[j][k] = this->mtx_ptr[jSelf][kSelf];
                 }
             }
             return subm;
         }
 
         /**
-         * Calculate determinant of matrix
+         * Calculate determinant of this matrix.
          * @return double The determinant
-         * @throw Exception If matrix isn't a square matrix - E_NOSQR
+         * @throw Exception If matrix isn't a square matrix - EX_NOSQR
          */
         double determinant()
         {
-            if (this->rows != this->cols)
-                this->throwException(E_NOSQR, "not a square matrix");
-            int n = this->rows;
+            if (this->rows() != this->cols())
+                Matrix::throwException(EX_NOSQR, "not a square matrix");
+            int n = this->rows();
             double det = 0;
             if (n == 1)
-                return this->get(0, 0);
+                return this->mtx_ptr[0][0];
             else if (n == 2)
-                return this->get(0, 0) * this->get(1, 1) - this->get(0, 1) * this->get(1, 0);
+                return this->mtx_ptr[0][0] * this->mtx_ptr[1][1] - this->mtx_ptr[0][1] * this->mtx_ptr[1][0];
             else
                 for (int i = 0; i < n; i++) {
-                    double coeff = pow(-1, i) * this->get(0, i);
-                    Matrix<type> subm = this->excludeRowCol(0, i);
+                    double coeff = pow(-1, i) * this->mtx_ptr[0][i];
+                    matrix<type> subm = this->excludeRowCol(0, i);
                     double subdet = subm.determinant();
                     double term = coeff * subdet;
                     det += term;

--- a/C++/libmatrix/library.md
+++ b/C++/libmatrix/library.md
@@ -27,20 +27,20 @@ int cols()
 ## Member functions
 
 #### Create a null matrix of given size
- - `param` n rows of matrix
- - `param` cols? cols of matrix
- - `return` matrix<type> a null matrix
- - `throws` Matrix::Exception row index out of bounds - `EX_ROUTB`
- - `throws` Matrix::Exception column index out of bounds - `EX_COUTB`
+ - `param` n Rows of matrix
+ - `param` cols? Cols of matrix
+ - `return` matrix<type> A null matrix
+ - `throws` Matrix::Exception Row index out of bounds - `EX_ROUTB`
+ - `throws` Matrix::Exception Column index out of bounds - `EX_COUTB`
 ```c++
 matrix<type> Matrix::O<type>(int n, int cols = 0)
 ```
 
 #### Create a unit matrix of given size
- - `param` n size of matrix
- - `return` matrix<type> a unit matrix
- - `throws` Matrix::Exception row index out of bounds - `EX_ROUTB`
- - `throws` Matrix::Exception column index out of bounds - `EX_COUTB`
+ - `param` n Size of matrix
+ - `return` matrix<type> A unit matrix
+ - `throws` Matrix::Exception Row index out of bounds - `EX_ROUTB`
+ - `throws` Matrix::Exception Column index out of bounds - `EX_COUTB`
 ```c++
 matrix<type> Matrix::I<type>(int n)
 ```
@@ -48,16 +48,16 @@ matrix<type> Matrix::I<type>(int n)
 #### Create null Matrix object
  - `param` rows If DDA is unknown, pass no. of rows
  - `param` cols If DDA is unknown, pass no. of cols
- - `throws` Matrix::Exception matrix can't have 0 rows - `EX_0ROWS`
- - `throws` Matrix::Exception matrix can't have 0 columns - `EX_0COLS`
+ - `throws` Matrix::Exception Matrix can't have 0 rows - `EX_0ROWS`
+ - `throws` Matrix::Exception Matrix can't have 0 columns - `EX_0COLS`
 ```c++
 matrix(int rows, int cols)
 ```
 
 #### Create a new matrix object
- - `param` 2D initializer list. See [demo.cpp](demo.cpp)
- - `throws` Matrix::Exception matrix can't have 0 rows - EX_0ROWS
- - `throws` Matrix::Exception matrix can't have 0 columns - EX_0COLS
+ - `param` lst 2D initializer list. See [demo.cpp](demo.cpp)
+ - `throws` Matrix::Exception Matrix can't have 0 rows - EX_0ROWS
+ - `throws` Matrix::Exception Matrix can't have 0 columns - EX_0COLS
 ```c++
 matrix(initializer_list<initializer_list<type>> lst)
 ```
@@ -67,8 +67,8 @@ The constructor accepts address to 1st element of the C++ DDA.
  - `param` rows Row size of DDA
  - `param` cols Column size of DDA
  - `param` arr If DDA is known, pass &dda[0][0]
- - `throws` Matrix::Exception matrix can't have 0 rows - `EX_0ROWS`
- - `throws` Matrix::Exception matrix can't have 0 columns - `EX_0COLS`
+ - `throws` Matrix::Exception Matrix can't have 0 rows - `EX_0ROWS`
+ - `throws` Matrix::Exception Matrix can't have 0 columns - `EX_0COLS`
 ```c++
 matrix(int rows, int cols, type *arr)
 ```
@@ -82,28 +82,28 @@ matrix(const matrix<type>& m2)
 ```
 
 #### Get an element of the matrix from an index
- - `param` i row wise position of element
- - `param` j column wise position of element
+ - `param` i Row wise position of element
+ - `param` j Column wise position of element
  - `return` type The value at index i, j
- - `throws` Matrix::Exception row index out of bounds - `EX_ROUTB`
- - `throws` Matrix::Exception column index out of bounds - `EX_COUTB`
+ - `throws` Matrix::Exception Row index out of bounds - `EX_ROUTB`
+ - `throws` Matrix::Exception Column index out of bounds - `EX_COUTB`
 ```c++
 type get(int i, int j)
 ```
 
 #### Set an element of the matrix to an index
- - `param` i row wise position of element
- - `param` j column wise position of element
- - `param` val value to be set
- - `throws` Matrix::Exception row index out of bounds - `EX_ROUTB`
- - `throws` Matrix::Exception column index out of bounds - `EX_COUTB`
+ - `param` i Row wise position of element
+ - `param` j Column wise position of element
+ - `param` val Value to be set
+ - `throws` Matrix::Exception Row index out of bounds - `EX_ROUTB`
+ - `throws` Matrix::Exception Column index out of bounds - `EX_COUTB`
 ```c++
 void set(int i, int j, type val)
 ```
 
 #### Compare two matrices for equality
  - `param` m2 The matrix to compare to
- - `return` boolean true if equal
+ - `return` boolean True if equal
 ```c++
 bool equals(const matrix<type>& m2)
 ```
@@ -142,7 +142,7 @@ matrix<type> multiply(const matrix<type>& m2)
 #### Calculate matrix to the power of +ve integer
  - `param` index Power of matrix
  - `return` matrix<type> The resulting matrix
- - `throws` Matrix::Exception same as errors of Matrix::multiply method
+ - `throws` Matrix::Exception Same as errors of Matrix::multiply method
 ```c++
 matrix<type> power(int index)
 ```
@@ -152,8 +152,8 @@ Useful for calculating determinants and cofactor matrices.
  - `param` row The row to exclude
  - `param` col The column to exclude
  - `return` matrix<type> The sub matrix
- - `throws` Matrix::Exception row index out of bounds - `EX_ROUTB`
- - `throws` Matrix::Exception column index out of bounds - `EX_COUTB`
+ - `throws` Matrix::Exception Row index out of bounds - `EX_ROUTB`
+ - `throws` Matrix::Exception Column index out of bounds - `EX_COUTB`
 ```c++
 matrix<type> excludeRowCol(int row, int col)
 ```
@@ -201,10 +201,10 @@ void print(const std::string& msg = "")
 
 ## Details of possible exceptions
 Each exception has type of `Matrix::Exception` and may have a value equal to the following
- - `EX_0ROWS`  matrix can't have 0 rows
- - `EX_0COLS`  matrix can't have 0 columns
- - `EX_ROUTB`  row index out of bounds
- - `EX_COUTB`  column index out of bounds
- - `EX_INCMP`  incompatible matrices
- - `EX_NOSQR`  not a square matrix
- - `EX_DETR0`  during inversion, determinant is 0
+ - `EX_0ROWS`  Matrix can't have 0 rows
+ - `EX_0COLS`  Matrix can't have 0 columns
+ - `EX_ROUTB`  Row index out of bounds
+ - `EX_COUTB`  Column index out of bounds
+ - `EX_INCMP`  Incompatible matrices
+ - `EX_NOSQR`  Not a square matrix
+ - `EX_DETR0`  During inversion, determinant is 0

--- a/C++/libmatrix/library.md
+++ b/C++/libmatrix/library.md
@@ -55,7 +55,7 @@ matrix(int rows, int cols)
 ```
 
 #### Create a new matrix object
- - `param` 2D initialiser list
+ - `param` 2D initializer list. See [demo.cpp](demo.cpp)
  - `throws` Matrix::Exception matrix can't have 0 rows - EX_0ROWS
  - `throws` Matrix::Exception matrix can't have 0 columns - EX_0COLS
 ```c++
@@ -64,7 +64,6 @@ matrix(initializer_list<initializer_list<type>> lst)
 
 #### Create Matrix object from DDA
 The constructor accepts address to 1st element of the C++ DDA.
-See [demo.cpp](demo.cpp).
  - `param` rows Row size of DDA
  - `param` cols Column size of DDA
  - `param` arr If DDA is known, pass &dda[0][0]

--- a/C++/libmatrix/library.md
+++ b/C++/libmatrix/library.md
@@ -208,3 +208,8 @@ Each exception has type of `Matrix::Exception` and may have a value equal to the
  - `EX_INCMP`  Incompatible matrices
  - `EX_NOSQR`  Not a square matrix
  - `EX_DETR0`  During inversion, determinant is 0
+
+## Compiler flags
+The following flags can be enabled by using `-D` option as a CLI argument to `g++` and `clang++`.
+ - `-D DEBUG` On `Matrix::Exception` prints the message.
+ - `-D ALLOW_PRIMITIVES_ONLY` Only allows matrix primitive datatype.

--- a/C++/libmatrix/library.md
+++ b/C++/libmatrix/library.md
@@ -1,75 +1,93 @@
 # Library Details
-Library namespace name: `mtx`
+Library namespace name: `Matrix`
 
-Library class name: `Matrix`
+Library class name: `matrix`
 
 ## Member variables
 
-#### Row size of matrix
+#### Row count of matrix
 ```c++
-int rows
+int rows()
 ```
 
-#### Column size of matrix
+#### Column count of matrix
 ```c++
-int cols
+int cols()
 ```
 
 ## Overloaded operators
- - `+` Adds 2 matrices
- - `-` Subtracts 2nd from 1st matrix
- - `*` Multiplies a matrix with a scalar or another matrix
- - `^` Calculates power (+ve integer) of a matrix
- - `==` Compares two matrices for equality
+ - `=` Copy matrix references
+ - `+` Add two matrices
+ - `-` Subtract 2nd from 1st matrix
+ - `*` Multiply a matrix with a scalar or another matrix
+ - `^` Calculate matrix to the power of +ve integer
+ - `==` Compare two matrices for equality
+ - `[][]` Access a posn of the matrix
 
 ## Member functions
 
 #### Create a null matrix of given size
  - `param` n rows of matrix
  - `param` cols? cols of matrix
- - `return` Matrix<type> a null matrix
- - `throws` mtx::Exception row index out of bounds - `E_ROUTB`
- - `throws` mtx::Exception column index out of bounds - `E_COUTB`
+ - `return` matrix<type> a null matrix
+ - `throws` Matrix::Exception row index out of bounds - `EX_ROUTB`
+ - `throws` Matrix::Exception column index out of bounds - `EX_COUTB`
 ```c++
-static Matrix<type> O(int n, int cols = 0)
+matrix<type> Matrix::O<type>(int n, int cols = 0)
 ```
 
 #### Create a unit matrix of given size
  - `param` n size of matrix
- - `return` Matrix<type> a unit matrix
- - `throws` mtx::Exception row index out of bounds - `E_ROUTB`
- - `throws` mtx::Exception column index out of bounds - `E_COUTB`
+ - `return` matrix<type> a unit matrix
+ - `throws` Matrix::Exception row index out of bounds - `EX_ROUTB`
+ - `throws` Matrix::Exception column index out of bounds - `EX_COUTB`
 ```c++
-static Matrix<type> I(int n)
+matrix<type> Matrix::I<type>(int n)
 ```
 
-#### Create empty matrix object
+#### Create null Matrix object
  - `param` rows If DDA is unknown, pass no. of rows
  - `param` cols If DDA is unknown, pass no. of cols
- - `throws` mtx::Exception matrix can't have 0 rows - `E_0ROWS`
- - `throws` mtx::Exception matrix can't have 0 columns - `E_0COLS`
+ - `throws` Matrix::Exception matrix can't have 0 rows - `EX_0ROWS`
+ - `throws` Matrix::Exception matrix can't have 0 columns - `EX_0COLS`
 ```c++
-explicit Matrix(int rows, int cols)
+matrix(int rows, int cols)
 ```
 
-#### Create matrix object from DDA
+#### Create a new matrix object
+ - `param` 2D initialiser list
+ - `throws` Matrix::Exception matrix can't have 0 rows - EX_0ROWS
+ - `throws` Matrix::Exception matrix can't have 0 columns - EX_0COLS
+```c++
+matrix(initializer_list<initializer_list<type>> lst)
+```
+
+#### Create Matrix object from DDA
 The constructor accepts address to 1st element of the C++ DDA.
 See [demo.cpp](demo.cpp).
  - `param` rows Row size of DDA
  - `param` cols Column size of DDA
  - `param` arr If DDA is known, pass &dda[0][0]
- - `throws` mtx::Exception matrix can't have 0 rows - `E_0ROWS`
- - `throws` mtx::Exception matrix can't have 0 columns - `E_0COLS`
+ - `throws` Matrix::Exception matrix can't have 0 rows - `EX_0ROWS`
+ - `throws` Matrix::Exception matrix can't have 0 columns - `EX_0COLS`
 ```c++
-explicit Matrix(int rows, int cols, type *arr)
+matrix(int rows, int cols, type *arr)
+```
+
+#### Copy a Matrix object via constructor
+Matrix uses smart reference counting approach.
+When all references are cleared, the memory is auto deleted on scope close.
+ - `param` m2 The source matrix
+```c++
+matrix(const matrix<type>& m2)
 ```
 
 #### Get an element of the matrix from an index
  - `param` i row wise position of element
  - `param` j column wise position of element
  - `return` type The value at index i, j
- - `throws` mtx::Exception row index out of bounds - `E_ROUTB`
- - `throws` mtx::Exception column index out of bounds - `E_COUTB`
+ - `throws` Matrix::Exception row index out of bounds - `EX_ROUTB`
+ - `throws` Matrix::Exception column index out of bounds - `EX_COUTB`
 ```c++
 type get(int i, int j)
 ```
@@ -78,8 +96,8 @@ type get(int i, int j)
  - `param` i row wise position of element
  - `param` j column wise position of element
  - `param` val value to be set
- - `throws` mtx::Exception row index out of bounds - `E_ROUTB`
- - `throws` mtx::Exception column index out of bounds - `E_COUTB`
+ - `throws` Matrix::Exception row index out of bounds - `EX_ROUTB`
+ - `throws` Matrix::Exception column index out of bounds - `EX_COUTB`
 ```c++
 void set(int i, int j, type val)
 ```
@@ -88,92 +106,92 @@ void set(int i, int j, type val)
  - `param` m2 The matrix to compare to
  - `return` boolean true if equal
 ```c++
-bool equals(Matrix<type>& m2)
+bool equals(const matrix<type>& m2)
 ```
 
 #### Add two compatible matrices
  - `param` m2 The matrix to add
- - `return` Matrix<type> The matrix of sums
- - `throws` mtx::Exception If matrices aren't compatible - `E_INCMP`
+ - `return` matrix<type> The matrix of sums
+ - `throws` Matrix::Exception If matrices aren't compatible - `EX_INCMP`
 ```c++
-Matrix<type> add(Matrix<type>& m2)
+matrix<type> add(const matrix<type>& m2)
 ```
 
-#### Subtract two compatible matrices
+#### Subtract 2nd from 1st matrix
  - `param` m2 The matrix to subtract
- - `return` Matrix<type> The matrix of differences
- - `throws` mtx::Exception If matrices aren't compatible - `E_INCMP`
+ - `return` matrix<type> The matrix of differences
+ - `throws` Matrix::Exception If matrices aren't compatible - `EX_INCMP`
 ```c++
-Matrix<type> subtract(Matrix<type>& m2)
+matrix<type> subtract(const matrix<type>& m2)
 ```
 
 #### Multiply a matrix by a scalar
  - `param` scalar Scalar to multiply by
  - `return` matrix The matrix of products
 ```c++
-Matrix<type> scale(type scalar)
+matrix<type> scale(type scalar)
 ```
 
 #### Multiply two compatible matrices
  - `param` m2 The matrix to multiply by
- - `return` Matrix<type> The matrix after multiplication
- - `throws` mtx::Exception If matrices aren't compatible - `E_INCMP`
+ - `return` matrix<type> The matrix after multiplication
+ - `throws` Matrix::Exception If matrices aren't compatible - `EX_INCMP`
 ```c++
-Matrix<type> multiply(Matrix<type>& m2)
+matrix<type> multiply(const matrix<type>& m2)
 ```
 
-#### Calculate matrix to the power of index
+#### Calculate matrix to the power of +ve integer
  - `param` index Power of matrix
- - `return` Matrix<type> The resulting matrix
- - `throws` mtx::Exception same as errors of Matrix::multiply method
+ - `return` matrix<type> The resulting matrix
+ - `throws` Matrix::Exception same as errors of Matrix::multiply method
 ```c++
-Matrix<type> power(int index)
+matrix<type> power(int index)
 ```
 
 #### Exclude a row and a column
 Useful for calculating determinants and cofactor matrices.
  - `param` row The row to exclude
  - `param` col The column to exclude
- - `return` Matrix<type> The sub matrix
- - `throws` mtx::Exception row index out of bounds - `E_ROUTB`
- - `throws` mtx::Exception column index out of bounds - `E_COUTB`
+ - `return` matrix<type> The sub matrix
+ - `throws` Matrix::Exception row index out of bounds - `EX_ROUTB`
+ - `throws` Matrix::Exception column index out of bounds - `EX_COUTB`
 ```c++
-Matrix<type> excludeRowCol(int row, int col)
+matrix<type> excludeRowCol(int row, int col)
 ```
 
-#### Calculate determinant of matrix
+#### Calculate determinant of this matrix
  - `return` double The determinant
- - `throw` mtx::Exception If matrix isn't a square matrix - `E_NOSQR`
+ - `throw` Matrix::Exception If matrix isn't a square matrix - `EX_NOSQR`
 ```c++
 double determinant()
 ```
 
 #### Calculate the transpose of this matrix
- - `return` Matrix<type> The transpose
+ - `return` matrix<type> The transpose
 ```c++
-Matrix<type> transpose()
+matrix<type> transpose()
 ```
 
 #### Calculate the cofactor matrix of this matrix
- - `return` Matrix<type> The cofactor matrix
- - `throws` mtx::Exception If matrix isn't a square matrix - `E_NOSQR`
+ - `return` matrix<type> The cofactor matrix
+ - `throws` Matrix::Exception If matrix isn't a square matrix - `EX_NOSQR`
 ```c++
-Matrix<type> cofactor()
+matrix<type> cofactor()
 ```
 
 #### Calculate the adjoint of this matrix
- - `return` Matrix<type> The adjoint
- - `throws` mtx::Exception If matrix isn't a square matrix - `E_NOSQR`
+ - `return` matrix<type> The adjoint
+ - `throws` Matrix::Exception If matrix isn't a square matrix - `EX_NOSQR`
 ```c++
-Matrix<type> adjoint()
+matrix<type> adjoint()
 ```
 
 #### Calculate the inverse of this matrix
- - `return` Matrix<double> The inverse
- - `throws` mtx::Exception If matrix isn't a square matrix - `E_NOSQR`
- - `throws` mtx::Exception If determinant is 0 - `E_DETR0`
+ - `return` matrix<double> The inverse
+ - `throws` Matrix::Exception If matrix isn't a square matrix - `EX_NOSQR`
+ - `throws` Matrix::Exception If determinant is 0 - `EX_DETR0`
 ```c++
-Matrix<double> inverse()
+matrix<double> inverse()
 ```
 
 #### Display the matrix
@@ -183,11 +201,11 @@ void print(const std::string& msg = "")
 ```
 
 ## Details of possible exceptions
-Each exception has type of `mtx::Exception` and may have a value equal to the following
- - `E_0ROWS`  matrix can't have 0 rows
- - `E_0COLS`  matrix can't have 0 columns
- - `E_ROUTB`  row index out of bounds
- - `E_COUTB`  column index out of bounds
- - `E_INCMP`  incompatible matrices
- - `E_NOSQR`  not a square matrix
- - `E_DETR0`  during inversion, determinant is 0
+Each exception has type of `Matrix::Exception` and may have a value equal to the following
+ - `EX_0ROWS`  matrix can't have 0 rows
+ - `EX_0COLS`  matrix can't have 0 columns
+ - `EX_ROUTB`  row index out of bounds
+ - `EX_COUTB`  column index out of bounds
+ - `EX_INCMP`  incompatible matrices
+ - `EX_NOSQR`  not a square matrix
+ - `EX_DETR0`  during inversion, determinant is 0

--- a/C++/libmatrix/library.md
+++ b/C++/libmatrix/library.md
@@ -212,4 +212,4 @@ Each exception has type of `Matrix::Exception` and may have a value equal to the
 ## Compiler flags
 The following flags can be enabled by using `-D` option as a CLI argument to `g++` and `clang++`.
  - `-D DEBUG` On `Matrix::Exception` prints the message.
- - `-D ALLOW_PRIMITIVES_ONLY` Only allows matrix primitive datatype.
+ - `-D ALLOW_PRIMITIVES_ONLY` Only allows matrix of primitive datatype.


### PR DESCRIPTION
#### Overloaded operator [ ]
```c++
matrix<int> m(5, 5);
m[2][3] = 11;
```

#### Constructor for 2D std::initializer_list
```c++
matrix<int> m2 {
    { 0, 2, 3, 4 },
    { 7, 1, 5, 6 },
    { 6, 5, 2, 7 },
    { 4, 3, 2, 3 }
};
```

#### Disabled default constructor
This is done to make sure a matrix always has its attributes (dimensions and data) defined.

This eliminates need to check a matrix for a nullptr attribute.
```c++
matrix<int> m;    // error
```

####  Excess features
1. Reference counter for smart memory management.
2. Overload `=` and add copy constructor.
